### PR TITLE
(fix) feastmode badge now correctly waits for 30 visits before being …

### DIFF
--- a/client/Accordion/Accordion.tsx
+++ b/client/Accordion/Accordion.tsx
@@ -110,7 +110,7 @@ export default () => {
       if (visits.length > 10) {
         setBadgeParliamentTruckaDelic(true);
       }
-      if (visits.length > 15) {
+      if (visits.length > 30) {
         setBadgeFeastMode(true);
       }
       if (


### PR DESCRIPTION
…awarded